### PR TITLE
CI: Build Python 3.10 wheels for Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Clone
@@ -73,7 +73,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Clone

--- a/src/lasunzipper.cpp
+++ b/src/lasunzipper.cpp
@@ -56,9 +56,9 @@ void LasUnZipper::decompress_into(py::buffer &buffer)
         throw std::invalid_argument("Buffer must be one dimensional");
     }
 
-    ssize_t num_points = buf_info.size / static_cast<ssize_t>(m_header->point_data_record_length);
+    py::ssize_t num_points = buf_info.size / static_cast<py::ssize_t>(m_header->point_data_record_length);
 
-    for (ssize_t i = 0; i < num_points; ++i)
+    for (py::ssize_t i = 0; i < num_points; ++i)
     {
 
         if (laszip_read_point(m_reader))


### PR DESCRIPTION
Add Python 3.10 to the Windows and macOS wheel build matrix.