### PR TITLE
Remove cmake and ninja build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.1.5",
-    "cmake>=3.20",
-    "ninja",
     "pybind11>=2.10",
 ]
 build-backend = "scikit_build_core.build"


### PR DESCRIPTION
One of the features of [scikit-build-core](https://github.com/scikit-build/scikit-build-core) (in contrast to scikit-build) is:

- Automatically adds Ninja and/or CMake only as required

This can be confirmed by [reading the code](https://github.com/scikit-build/scikit-build-core/blob/c22a7ed3e1e939b538fc43f5fe4bdb6f639169e6/src/scikit_build_core/build/__init__.py#L120), where it will add the cmake and ninja packages from PyPI if it does not detect the corresponding tool is already present in the environment.

I'm interested in this for [nixpkgs](https://github.com/NixOS/nixpkgs). We use [`build`](https://pypa-build.readthedocs.io/en/latest/) to build Python packages, and that validates build dependencies are present. Instead of passing the cmake and ninja PyPI packages, we'd like to make the cmake and ninja tools available directly.