### PR TITLE
Fix Incorrect Pointer Increment in the function `LasZipper::compress()`

### DIFF
--- a/src/laszipper.cpp
+++ b/src/laszipper.cpp
@@ -76,13 +76,14 @@ size_t LasZipper::compress(py::buffer &buffer)
     while (num_points_in_buffer != 0)
     {
         m_is.seekp(0);
-        m_is.seekg(0);
 
         py::ssize_t num_points_for_this_iter =
             std::min(num_points_in_buffer, max_points_before_filling_stream);
         size_t num_bytes_for_this_iter =
             num_points_for_this_iter * static_cast<size_t>(m_header->point_data_record_length);
         m_is.write(in_ptr, num_bytes_for_this_iter);
+
+        m_is.seekg(0);
 
         for (size_t i{0}; i < num_points_for_this_iter; ++i)
         {
@@ -107,7 +108,7 @@ size_t LasZipper::compress(py::buffer &buffer)
             }
         }
 
-        in_ptr += num_points_for_this_iter;
+        in_ptr += num_bytes_for_this_iter;
         num_points_in_buffer -= num_points_for_this_iter;
     }
 


### PR DESCRIPTION
Hi,

First of all, thank you for providing this very useful library! I suspect there is a bug in `laspy` when handling large point clouds that originates from the `LasZipper::compress()` function.

### 1. Fix pointer increment when processing large buffers

When the input buffer is very large, it gets split into several chunks. In those cases, the current code moves `in_ptr` forward by the number of points, but `in_ptr` is a **byte pointer**, so it should move by the number of bytes instead.

This patch changes the increment to:

``` cpp
in_ptr += num_bytes_for_this_iter;
```

which ensures that the pointer increment logic is correct.

### 2. Move `seekg(0)` to after the write (minor improvement)

The patch also executes the reset of the read pointer after writing data into stringstream. This wasn’t a strict bug, as the original ordering often worked, but this ordering makes it clearer and reduces the chance of subtle ordering issues.


Thanks again for the great library and for taking the time to review this patch!